### PR TITLE
Fix deploy.yml to correct artifact path and zip options

### DIFF
--- a/.github/workflows/main_app-002-step3-2-py-oshima8.yml
+++ b/.github/workflows/main_app-002-step3-2-py-oshima8.yml
@@ -39,15 +39,13 @@ jobs:
       # Optional: Add step to run tests here (PyTest, Django test suites, etc.)
 
       - name: Zip artifact for deployment
-        run: zip release.zip ./* -r
+        run: zip -r release.zip . -x "venv/*"
 
       - name: Upload artifact for deployment jobs
         uses: actions/upload-artifact@v4
         with:
           name: python-app
-          path: |
-            release.zip
-            !venv/
+          path: backend/release.zip
 
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
💥 Before（修正前）
.github/workflows/deploy.yml の中で、
release.zip というファイルを作るときに 不要なフォルダも含んでしまったり
アップロードする zip ファイルの場所や内容の指定方法が間違っていたり していた。
そのせいで、GitHub Actions の「デプロイ工程」が失敗していた。

✅ After（修正後）
Zipファイルの作り方を見直して
アップロードするファイルを正しく指定するように変更した。
不要な venv/（仮想環境フォルダ）を zip に入れないようにした。
アップロード時のパスの書き方も GitHub Actions に正しく認識されるように調整。