### PR TITLE
ユーザー情報更新機能の追加（/users/{id}, /users/me）

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ DB_HOST=your_host.mysql.database.azure.com
 DB_PORT=3306
 DB_NAME=step3_2_hondaken
 
+AZURE_STORAGE_ACCOUNT_NAME=blobstep32
+AZURE_BLOB_CONTAINER_NAME=team8-hondadog-locations
+AZURE_BLOB_PATH=location_images/
+
 4. 起動
 bash
 コピーする

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -20,34 +20,13 @@ from app.core.security import (
 from app.core.database import get_db
 from app.crud.user import get_user_by_email, create_user  # ← 🔄 登録処理を呼び出す
 from app.models.user import User
+from app.core.auth import get_current_user
 
 router = APIRouter()
 
 # トークン取得に使われる依存関数
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login")
 
-# ✅ トークンから現在のユーザーを取得
-def get_current_user(
-    token: str = Depends(oauth2_scheme),
-    db: Session = Depends(get_db)
-) -> User:
-    credentials_exception = HTTPException(
-        status_code=status.HTTP_401_UNAUTHORIZED,
-        detail="Could not validate credentials",
-        headers={"WWW-Authenticate": "Bearer"},
-    )
-    try:
-        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
-        email: Optional[str] = payload.get("sub")
-        if email is None:
-            raise credentials_exception
-    except JWTError:
-        raise credentials_exception
-
-    user = get_user_by_email(db, email)
-    if user is None:
-        raise credentials_exception
-    return user
 
 # 🔐 ログイン処理
 @router.post("/auth/login", response_model=Token)

--- a/backend/app/api/user.py
+++ b/backend/app/api/user.py
@@ -2,9 +2,11 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from typing import List
 
-from app.schemas.user import User, UserCreate
+from app.schemas.user import User, UserCreate, UserUpdate
 from app.crud import user as crud
 from app.core.database import SessionLocal
+from app.models.user import User as UserModel
+from app.core.auth import get_current_user
 
 router = APIRouter(
     prefix="/users",
@@ -42,6 +44,24 @@ def read_user(user_id: int, db: Session = Depends(get_db)):
     if db_user is None:
         raise HTTPException(status_code=404, detail="User not found")
     return db_user
+
+# ログインユーザー自身の情報を更新（マイページ用）PUT /users/me
+@router.put("/me", response_model=User)
+def update_my_info(
+    user_update: UserUpdate,
+    db: Session = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user)
+):
+    updated_user = crud.update_user(db, user_id=current_user.id, updates=user_update.dict(exclude_unset=True))
+    return updated_user
+
+# ユーザー情報を任意に更新（管理者用・非認証）PUT /users/{user_id}
+@router.put("/{user_id}", response_model=User)
+def update_user_info(user_id: int, user_update: UserUpdate, db: Session = Depends(get_db)):
+    updated_user = crud.update_user(db, user_id=user_id, updates=user_update.dict(exclude_unset=True))
+    if updated_user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    return updated_user
 
 #from app.core.auth import get_current_user  # ← 忘れずにインポート！
 #from app.models.user import User as UserModel  # ← DBモデルのUser

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -1,0 +1,34 @@
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from jose import JWTError, jwt
+from sqlalchemy.orm import Session
+from typing import Optional
+
+from app.core.database import get_db
+from app.models.user import User
+from app.crud.user import get_user_by_email
+from app.core.security import SECRET_KEY, ALGORITHM
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login")
+
+def get_current_user(
+    token: str = Depends(oauth2_scheme),
+    db: Session = Depends(get_db)
+) -> User:
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        email: Optional[str] = payload.get("sub")
+        if email is None:
+            raise credentials_exception
+    except JWTError:
+        raise credentials_exception
+
+    user = get_user_by_email(db, email)
+    if user is None:
+        raise credentials_exception
+    return user

--- a/backend/app/crud/user.py
+++ b/backend/app/crud/user.py
@@ -47,3 +47,15 @@ def get_user_by_id(db: Session, user_id: int) -> Optional[User]:
 # Email で取得（ログインなどで使用予定）
 def get_user_by_email(db: Session, email: str) -> Optional[User]:
     return db.query(User).filter(User.email == email).first()
+
+# 任意フィールドを更新する関数（PUT用）
+def update_user(db: Session, user_id: int, updates: dict) -> Optional[User]:
+    db_user = db.query(User).filter(User.id == user_id).first()
+    if db_user is None:
+        return None
+    for key, value in updates.items():
+        if hasattr(db_user, key) and value is not None:
+            setattr(db_user, key, value)
+    db.commit()
+    db.refresh(db_user)
+    return db_user

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -30,3 +30,18 @@ class User(UserBase):
 
     class Config:
         orm_mode = True
+
+class UserUpdate(BaseModel):
+    name_last: Optional[str] = None
+    name_first: Optional[str] = None
+    email: Optional[EmailStr] = None
+    birthday: Optional[datetime] = None
+    postal_code: Optional[str] = None
+    prefecture: Optional[str] = None
+    city: Optional[str] = None
+    address_line: Optional[str] = None
+    phone_number: Optional[str] = None
+    gender: Optional[str] = None
+    google_id: Optional[str] = None
+    profile_image_url: Optional[str] = None
+    line_u_id: Optional[str] = None


### PR DESCRIPTION
## 概要
- ユーザー情報の更新ができるAPIを2種類追加しました。

## 追加内容
- `PUT /users/{user_id}`：任意のユーザー情報を非認証で更新（管理者用）
- `PUT /users/me`：ログインユーザー自身の情報をJWT認証付きで更新
- `UserUpdate` スキーマを `schemas/user.py` に追加（部分更新に対応）
- `crud/user.py` に `update_user()` 関数を追加し、任意項目更新が可能に
- `get_current_user()` を `app/api/auth.py` から `app/core/auth.py` に移動して再利用性向上

## 確認方法
- Swagger UI にて `/auth/login` でトークン取得 → `/users/me` で更新成功確認済み
- curl でも `/users/me` に対し `Authorization: Bearer <token>` ヘッダー付きで成功確認済み
- `PUT /users/{id}` は認証不要で動作し、任意のユーザー情報を更新可能

## 補足
- FastAPIのルーティング優先順位の関係で `/users/me` を `/users/{user_id}` より上に定義
- `orm_mode` のPydantic警告については今後V2対応で調整予定